### PR TITLE
Add Layouts AJAX response filter

### DIFF
--- a/inc/admin-layouts.php
+++ b/inc/admin-layouts.php
@@ -308,7 +308,7 @@ class SiteOrigin_Panels_Admin_Layouts {
 			$return['title'] .= __( ' - Results For:', 'siteorigin-panels' ) . ' <em>' . esc_html( $search ) . '</em>';
 		}
 		
-		echo json_encode( $return );
+		echo json_encode( apply_filters( 'siteorigin_panels_layouts_result', $return, $type ) );
 		
 		wp_die();
 	}


### PR DESCRIPTION
We're in a situation where we would like to add a simple "Favorites" filter to the layouts response - so only posts with a certain meta data will be shown - but there is no way for us to hook in and do this.

One way to allow this is to add an option for early opt-in to take over the results (an `if` condition before the [prebuilt condition](https://github.com/siteorigin/siteorigin-panels/blob/develop/inc/admin-layouts.php#L198)?)

But we can also achieve the same results if we get a filter for the final response and I feel like this - in general - is just a good addition to developers. So for now this would be my "I hope they accept it quickly" suggestion as seen in the PR :relaxed:

Best regards